### PR TITLE
🔧 chore(mongoose.config.js): import connect function from mongoose in…

### DIFF
--- a/server/config/mongoose.config.js
+++ b/server/config/mongoose.config.js
@@ -1,7 +1,7 @@
-const mongoose = require('mongoose');
+import { connect } from 'mongoose';
 const uri = process.env.MONGO_DB_URI;
 
-mongoose.connect(uri, {
+connect(uri, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
 })

--- a/server/controllers/lead.controller.js
+++ b/server/controllers/lead.controller.js
@@ -1,34 +1,34 @@
-const Lead = require('../models/lead.model');
+import Lead from '../models/lead.model';
 
 /* Mongoose methods to interact with our MongoDB*/
 
 //CREATE Lead
-module.exports.createOneLead = (req, res) => {
+export function createOneLead(req, res) {
     console.log(req.body);
     Lead.create(req.body)
         .then((lead) => {return res.json(lead);})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})});
 }
 //GET all Leads
-module.exports.getAllLeads = (req, res) => {
+export function getAllLeads(req, res) {
     Lead.find().sort({email: 1})
         .then((allLeads) => {res.json(allLeads)})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})});
 }
 //GET one Lead by ID
-module.exports.getOneLeadById = (req, res) => {
+export function getOneLeadById(req, res) {
     Lead.findOne({ _id: req.params.id })
         .then(oneLead => {res.json(oneLead)})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})});
 }
 //DELETE one Lead by ID
-module.exports.deleteOneLeadById = (req, res) => {
+export function deleteOneLeadById(req, res) {
     Lead.deleteOne({ _id: req.params.id })
         .then(result => {res.json(result)})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})})
 }
 //UPDATE one Lead by ID
-module.exports.updateOneLeadById = (req, res) => {
+export function updateOneLeadById(req, res) {
     Lead.findOneAndUpdate( { _id: req.params.id }, req.body, { new: true, runValidators: true } )
         .then(updatedLead => {res.json(updatedLead)})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})});

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -1,34 +1,34 @@
-const User = require('../models/user.model');
+import User from '../models/user.model';
 
 /* Mongoose methods to interact with our MongoDB*/
 
 //CREATE User
-module.exports.createOneUser = (req, res) => {
+export function createOneUser(req, res) {
     console.log(req.body);
     User.create(req.body)
         .then((user) => {return res.json(user);})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})});
 }
 //GET all Users
-module.exports.getAllUsers = (req, res) => {
+export function getAllUsers(req, res) {
     User.find().sort({email: 1})
         .then((allUsers) => {res.json(allUsers)})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})});
 }
 //GET one User by ID
-module.exports.getOneUserById = (req, res) => {
+export function getOneUserById(req, res) {
     User.findOne({ _id: req.params.id })
         .then(oneUser => {res.json(oneUser)})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})});
 }
 //DELETE one User by ID
-module.exports.deleteOneUserById = (req, res) => {
+export function deleteOneUserById(req, res) {
     User.deleteOne({ _id: req.params.id })
         .then(result => {res.json(result)})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})})
 }
 //UPDATE one User by ID
-module.exports.updateOneUserById = (req, res) => {
+export function updateOneUserById(req, res) {
     User.findOneAndUpdate( { _id: req.params.id }, req.body, { new: true, runValidators: true } )
         .then(updatedUser => {res.json(updatedUser)})
         .catch((err) => {res.status(400).json({ ...err, message: err.message})});

--- a/server/models/lead.model.js
+++ b/server/models/lead.model.js
@@ -1,10 +1,10 @@
-const mongoose = require('mongoose');
-require('mongoose-type-email');
+import { Schema, SchemaTypes, model } from 'mongoose';
+import 'mongoose-type-email';
 //create the Lead schema with validations
-const LeadSchema = new mongoose.Schema({
+const LeadSchema = new Schema({
     //mongoose added Email datatype that auto validates using an email regex
     email: {
-        type: mongoose.SchemaTypes.Email,
+        type: SchemaTypes.Email,
         correctTld: true, //correctTld is stronger email validation
         index: true,
         required: [true, 'Email is required!'],
@@ -46,5 +46,5 @@ const LeadSchema = new mongoose.Schema({
     }
 });
 
-const Lead = mongoose.model('Lead', LeadSchema);
-module.exports = Lead;
+const Lead = model('Lead', LeadSchema);
+export default Lead;

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -1,10 +1,10 @@
-const mongoose = require('mongoose');
-require('mongoose-type-email');
+import { Schema, SchemaTypes, model } from 'mongoose';
+import 'mongoose-type-email';
 //create the User schema with validations
-const UserSchema = new mongoose.Schema({
+const UserSchema = new Schema({
     //mongoose added Email datatype that auto validates using an email regex
     email: {
-        type: mongoose.SchemaTypes.Email,
+        type: SchemaTypes.Email,
         correctTld: true, //correctTld is stronger email validation
         index: true,
         required: [true, 'Email is required!'],
@@ -33,5 +33,5 @@ const UserSchema = new mongoose.Schema({
         required: false
     }
 });
-const User = mongoose.model('User', UserSchema);
-module.exports = User;
+const User = model('User', UserSchema);
+export default User;

--- a/server/routes/lead.routes.js
+++ b/server/routes/lead.routes.js
@@ -1,8 +1,8 @@
-const LeadController = require('../controllers/lead.controller');
-module.exports = function(app) {
-    app.get('/api/leads', LeadController.getAllLeads)
-    app.post('/api/leads', LeadController.createOneLead)
-    app.get('/api/leads/:id', LeadController.getOneLeadById)
-    app.put('/api/leads/:id', LeadController.updateOneLeadById)
-    app.delete('/api/leads/:id', LeadController.deleteOneLeadById)
+import { getAllLeads, createOneLead, getOneLeadById, updateOneLeadById, deleteOneLeadById } from '../controllers/lead.controller';
+export default function(app) {
+    app.get('/api/leads', getAllLeads)
+    app.post('/api/leads', createOneLead)
+    app.get('/api/leads/:id', getOneLeadById)
+    app.put('/api/leads/:id', updateOneLeadById)
+    app.delete('/api/leads/:id', deleteOneLeadById)
 }

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -1,8 +1,8 @@
-const UserController = require('../controllers/user.controller');
-module.exports = function(app) {
-    app.get('/api/users', UserController.getAllUsers)
-    app.post('/api/users', UserController.createOneUser)
-    app.get('/api/users/:id', UserController.getOneUserById)
-    app.put('/api/users/:id', UserController.updateOneUserById)
-    app.delete('/api/users/:id', UserController.deleteOneUserById)
+import { getAllUsers, createOneUser, getOneUserById, updateOneUserById, deleteOneUserById } from '../controllers/user.controller';
+export default function(app) {
+    app.get('/api/users', getAllUsers)
+    app.post('/api/users', createOneUser)
+    app.get('/api/users/:id', getOneUserById)
+    app.put('/api/users/:id', updateOneUserById)
+    app.delete('/api/users/:id', deleteOneUserById)
 }


### PR DESCRIPTION
…stead of requiring mongoose

✨ feat(lead.controller.js): export controller functions as named exports instead of module.exports ✨ feat(user.controller.js): export controller functions as named exports instead of module.exports 🔧 chore(lead.model.js): import Schema, SchemaTypes, and model from mongoose instead of requiring mongoose 🔧 chore(user.model.js): import Schema, SchemaTypes, and model from mongoose instead of requiring mongoose 🔧 chore(lead.routes.js): import controller functions as named exports instead of requiring them 🔧 chore(user.routes.js): import controller functions as named exports instead of requiring them The changes made in this commit are mostly related to code organization and best practices. The changes include importing functions and objects from mongoose instead of requiring the entire mongoose library, exporting controller functions as named exports instead of using module.exports, and importing controller functions as named exports instead of